### PR TITLE
MANTA-4387 [mantav1] update Moray to use artedi v2 fixed buckets histograms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 #
-# Copyright 2019 Joyent, Inc.
+# Copyright 2020 Joyent, Inc.
 #
 
 #

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var util = require('util');
@@ -153,6 +153,7 @@ function MorayServer(options) {
         help: 'The node-fast CRC compatibilty mode of the Fast server'
     }).set(crc_mode);
 
+    collector.FIXED_BUCKETS = true;
     var socket = mod_net.createServer({ 'allowHalfOpen': true });
     var server = new mod_fast.FastServer({
         log: log.child({ component: 'fast' }),

--- a/lib/server.js
+++ b/lib/server.js
@@ -153,7 +153,6 @@ function MorayServer(options) {
         help: 'The node-fast CRC compatibilty mode of the Fast server'
     }).set(crc_mode);
 
-    collector.FIXED_BUCKETS = true;
     var socket = mod_net.createServer({ 'allowHalfOpen': true });
     var server = new mod_fast.FastServer({
         log: log.child({ component: 'fast' }),

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
     "name": "moray-server",
     "description": "SmartDataCenter H/A Key/Value store",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "author": "Joyent (joyent.com)",
     "private": true,
     "main": "lib/index.js",
     "dependencies": {
         "ajv": "4.11.4",
-        "artedi": "1.3.0",
+        "artedi": "2.0.0",
         "assert-plus": "1.0.0",
         "bunyan": "1.8.10",
         "bunyan-syslog": "~0.3.2",


### PR DESCRIPTION
This small change updates moray to use artedi v2, mainly to make use of fixed buckets histograms introduced in v2. See testing notes in the ticket.

For some reason, I had to update the copyright in `Makefile` to 2020 in order for `make check` to pass.