### PR TITLE
MANTA-4991 Update moray to use node-fast 3.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+# moray Changelog
+
+## 2.4.0
+
+- [#18](https://github.com/joyent/moray/issues/18) Update moray to use node-fast
+  3.0.0. Node-fast version 3.0.0 moves the fast protocol version to
+  version 2. Severs using node-fast 3.0.0 can still communicate with clients
+  using fast protocol version 1 so updating to this version should not adversely
+  impact any existing moray clients.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 /*
@@ -378,7 +378,6 @@ AJV_ENV.addSchema({
     properties: {
         'log': { allOf: [ { '$ref': 'object' } ] },
         'bunyan': { allOf: [ { '$ref': 'object' } ] },
-        'fast': { allOf: [ { '$ref': 'object' } ] },
         'name': { allOf: [ { '$ref': 'string' } ] },
         'file': { allOf: [ { '$ref': 'string' } ] },
         'bindip': { allOf: [ { '$ref': 'string' } ] },

--- a/lib/server.js
+++ b/lib/server.js
@@ -145,20 +145,11 @@ function MorayServer(options) {
         objectCache: this.ms_objectCache
     };
 
-    var crc_mode = options.fast.crc_mode ||
-        mod_fast.FAST_CHECKSUM_V1;
-
-    collector.gauge({
-        name: 'fast_server_crc_mode',
-        help: 'The node-fast CRC compatibilty mode of the Fast server'
-    }).set(crc_mode);
-
     var socket = mod_net.createServer({ 'allowHalfOpen': true });
     var server = new mod_fast.FastServer({
         log: log.child({ component: 'fast' }),
         collector: collector,
-        server: socket,
-        crc_mode: crc_mode
+        server: socket
     });
 
     var methods = [
@@ -309,10 +300,6 @@ MorayServer.prototype.close = function close() {
 function createServer(options) {
     assert.object(options, 'options');
     assert.object(options.log, 'options.log');
-    assert.optionalObject(options.fast, 'options.fast');
-    options.fast = options.fast || {};
-    assert.optionalNumber(options.fast.crc_mode,
-        'options.fast.crc_mode');
 
     return new MorayServer(options);
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "moray-server",
     "description": "SmartDataCenter H/A Key/Value store",
-    "version": "2.3.1",
+    "version": "2.4.0",
     "author": "Joyent (joyent.com)",
     "private": true,
     "main": "lib/index.js",
@@ -17,7 +17,7 @@
         "dtrace-provider": "~0.8",
         "deep-equal": "0.0.0",
         "exeunt": "^1.1.1",
-        "fast": "2.8.1",
+        "fast": "3.0.0",
         "forkexec": "^1.1.0",
         "ip6addr": "0.2.2",
         "jsprim": "1.4.0",

--- a/sapi_manifests/moray/template
+++ b/sapi_manifests/moray/template
@@ -6,14 +6,6 @@
       "type": "udp"
     }
   },
-  "fast": {
-    {{#MORAY_FAST_CRC_MODE}}
-    "crc_mode": {{MORAY_FAST_CRC_MODE}}
-    {{/MORAY_FAST_CRC_MODE}}
-    {{^MORAY_FAST_CRC_MODE}}
-    "crc_mode": 2
-    {{/MORAY_FAST_CRC_MODE}}
-  },
   "manatee": {
     "manatee": {
       "path": "/manatee/{{SERVICE_NAME}}",


### PR DESCRIPTION
Backport of MANTA-4991 commit to `mantav1` branch.